### PR TITLE
Reload collection view in a serial manner

### DIFF
--- a/ImagePicker.xcodeproj/project.pbxproj
+++ b/ImagePicker.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		427926021F96407900B6D55F /* LivePhotoCameraCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 427926001F963E9C00B6D55F /* LivePhotoCameraCell.xib */; };
 		42990DBF1FA07AF7001658C4 /* RecordDurationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42990DBE1FA07AF7001658C4 /* RecordDurationLabel.swift */; };
 		429BFDAA1F68161D00029440 /* ImagePickerAssetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429BFDA91F68161D00029440 /* ImagePickerAssetModel.swift */; };
+		429CCBD02080D62F0050078B /* AsynchronousOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429CCBCF2080D62F0050078B /* AsynchronousOperation.swift */; };
+		429CCBD22080D6620050078B /* CollectionViewBatchAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429CCBD12080D6620050078B /* CollectionViewBatchAnimation.swift */; };
+		429CCBD42080D6AE0050078B /* CollectionViewUpdatesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429CCBD32080D6AE0050078B /* CollectionViewUpdatesCoordinator.swift */; };
 		42A037E01F66C9E700534350 /* CustomVideoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 42A037DF1F66C9E700534350 /* CustomVideoCell.xib */; };
 		42B296A91FB1CC3200590260 /* ImagePickerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 42B296A81FB1CC3200590260 /* ImagePickerView.xib */; };
 		42B296AB1FB1CC7400590260 /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B296AA1FB1CC7400590260 /* ImagePickerView.swift */; };
@@ -124,6 +127,9 @@
 		427926001F963E9C00B6D55F /* LivePhotoCameraCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LivePhotoCameraCell.xib; sourceTree = "<group>"; };
 		42990DBE1FA07AF7001658C4 /* RecordDurationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordDurationLabel.swift; sourceTree = "<group>"; };
 		429BFDA91F68161D00029440 /* ImagePickerAssetModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerAssetModel.swift; sourceTree = "<group>"; };
+		429CCBCF2080D62F0050078B /* AsynchronousOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsynchronousOperation.swift; sourceTree = "<group>"; };
+		429CCBD12080D6620050078B /* CollectionViewBatchAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewBatchAnimation.swift; sourceTree = "<group>"; };
+		429CCBD32080D6AE0050078B /* CollectionViewUpdatesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewUpdatesCoordinator.swift; sourceTree = "<group>"; };
 		42A037DF1F66C9E700534350 /* CustomVideoCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomVideoCell.xib; sourceTree = "<group>"; };
 		42B296A81FB1CC3200590260 /* ImagePickerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImagePickerView.xib; sourceTree = "<group>"; };
 		42B296AA1FB1CC7400590260 /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
@@ -196,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				420C24181F5D82F9008935D4 /* ImagePicker.h */,
+				42887C072080D5D200194155 /* Operations */,
 				42D7036F1F7909100057D557 /* Public */,
 				42D703701F790A3F0057D557 /* Media */,
 				42990DBD1FA07A6C001658C4 /* Views */,
@@ -225,6 +232,16 @@
 				421442701F604993006BA45A /* IconWithTextCell.swift */,
 			);
 			path = "Custom Views";
+			sourceTree = "<group>";
+		};
+		42887C072080D5D200194155 /* Operations */ = {
+			isa = PBXGroup;
+			children = (
+				429CCBCF2080D62F0050078B /* AsynchronousOperation.swift */,
+				429CCBD12080D6620050078B /* CollectionViewBatchAnimation.swift */,
+				429CCBD32080D6AE0050078B /* CollectionViewUpdatesCoordinator.swift */,
+			);
+			name = Operations;
 			sourceTree = "<group>";
 		};
 		42990DBD1FA07A6C001658C4 /* Views */ = {
@@ -415,6 +432,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				421442631F6014B3006BA45A /* CellRegistrator.swift in Sources */,
+				429CCBD22080D6620050078B /* CollectionViewBatchAnimation.swift in Sources */,
+				429CCBD42080D6AE0050078B /* CollectionViewUpdatesCoordinator.swift in Sources */,
 				420C24361F5ED4AB008935D4 /* ImagePickerLayout.swift in Sources */,
 				42D0979C1F7BF6B300A66E33 /* AssetCell.swift in Sources */,
 				42E736521F8510B70060E24D /* VideoCaptureDelegate.swift in Sources */,
@@ -431,6 +450,7 @@
 				427925F51F96381400B6D55F /* ShutterButton.swift in Sources */,
 				42EDD4061F71261600EAD2F5 /* AVPreviewView.swift in Sources */,
 				420C24411F5EEA3C008935D4 /* LayoutConfiguration.swift in Sources */,
+				429CCBD02080D62F0050078B /* AsynchronousOperation.swift in Sources */,
 				427925FD1F963A8D00B6D55F /* VideoCameraCell.swift in Sources */,
 				42EDD4161F712B2A00EAD2F5 /* Miscellaneous.swift in Sources */,
 				427926011F963E9C00B6D55F /* LivePhotoCameraCell.swift in Sources */,

--- a/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ImagePicker/AsynchronousOperation.swift
+++ b/ImagePicker/AsynchronousOperation.swift
@@ -36,7 +36,6 @@ class AsynchronousOperation : Foundation.Operation {
     }
     
     override func main() {
-        
         if isCancelled {
             completeOperation()
         }
@@ -51,7 +50,6 @@ class AsynchronousOperation : Foundation.Operation {
     }
     
     func completeOperation() {
-        
         if self.stateExecuting == true {
             self.stateExecuting = false
         }
@@ -60,5 +58,4 @@ class AsynchronousOperation : Foundation.Operation {
             self.stateFinished = true
         }
     }
-    
 }

--- a/ImagePicker/AsynchronousOperation.swift
+++ b/ImagePicker/AsynchronousOperation.swift
@@ -1,0 +1,64 @@
+//
+//  AsynchronousOperation.swift
+//  ImagePicker
+//
+//  Created by Peter Stajger on 13/04/2018.
+//  Copyright © 2018 Inloop. All rights reserved.
+//
+
+import Foundation
+
+///
+/// Provides primitives for wrapping Operation with asynchronous code that can
+/// be enqueued in a OperationQueue and run serially.
+///
+class AsynchronousOperation : Foundation.Operation {
+    
+    var stateFinished: Bool = false {
+        willSet { willChangeValue(forKey: "isFinished") }
+        didSet { didChangeValue(forKey: "isFinished") }
+    }
+    var stateExecuting: Bool = false {
+        willSet { willChangeValue(forKey: "isExecuting") }
+        didSet { didChangeValue(forKey: "isExecuting") }
+    }
+    
+    override var isFinished: Bool {
+        return stateFinished
+    }
+    
+    override var isExecuting: Bool {
+        return stateExecuting
+    }
+    
+    override var isAsynchronous: Bool {
+        return true
+    }
+    
+    override func main() {
+        
+        if isCancelled {
+            completeOperation()
+        }
+        else {
+            stateExecuting = true
+            execute()
+        }
+    }
+    
+    func execute() {
+        fatalError("This method has to be overriden")
+    }
+    
+    func completeOperation() {
+        
+        if self.stateExecuting == true {
+            self.stateExecuting = false
+        }
+        
+        if self.stateFinished == false {
+            self.stateFinished = true
+        }
+    }
+    
+}

--- a/ImagePicker/CollectionViewBatchAnimation.swift
+++ b/ImagePicker/CollectionViewBatchAnimation.swift
@@ -13,7 +13,6 @@ import Photos
 /// Wraps collectionView's `performBatchUpdates` block into AsynchronousOperation.
 ///
 final class CollectionViewBatchAnimation<ObjectType> : AsynchronousOperation where ObjectType : PHObject {
-    
     private let collectionView: UICollectionView
     private let sectionIndex: Int
     private let changes: PHFetchResultChangeDetails<ObjectType>
@@ -25,7 +24,6 @@ final class CollectionViewBatchAnimation<ObjectType> : AsynchronousOperation whe
     }
     
     override func execute() {
-        
         // If we have incremental diffs, animate them in the collection view
         collectionView.performBatchUpdates({ [unowned self] in
             
@@ -46,7 +44,5 @@ final class CollectionViewBatchAnimation<ObjectType> : AsynchronousOperation whe
             }, completion: { finished in
                 self.completeOperation()
         })
-        
     }
-    
 }

--- a/ImagePicker/CollectionViewBatchAnimation.swift
+++ b/ImagePicker/CollectionViewBatchAnimation.swift
@@ -1,0 +1,52 @@
+//
+//  CollectionViewBatchAnimation.swift
+//  ImagePicker
+//
+//  Created by Peter Stajger on 13/04/2018.
+//  Copyright © 2018 Inloop. All rights reserved.
+//
+
+import UIKit
+import Photos
+
+///
+/// Wraps collectionView's `performBatchUpdates` block into AsynchronousOperation.
+///
+final class CollectionViewBatchAnimation<ObjectType> : AsynchronousOperation where ObjectType : PHObject {
+    
+    private let collectionView: UICollectionView
+    private let sectionIndex: Int
+    private let changes: PHFetchResultChangeDetails<ObjectType>
+    
+    init(collectionView: UICollectionView, sectionIndex: Int, changes: PHFetchResultChangeDetails<ObjectType>) {
+        self.collectionView = collectionView
+        self.sectionIndex = sectionIndex
+        self.changes = changes
+    }
+    
+    override func execute() {
+        
+        // If we have incremental diffs, animate them in the collection view
+        collectionView.performBatchUpdates({ [unowned self] in
+            
+            // For indexes to make sense, updates must be in this order:
+            // delete, insert, reload, move
+            if let removed = self.changes.removedIndexes, removed.isEmpty == false {
+                self.collectionView.deleteItems(at: removed.map({ IndexPath(item: $0, section: self.sectionIndex) }))
+            }
+            if let inserted = changes.insertedIndexes, inserted.isEmpty == false {
+                self.collectionView.insertItems(at: inserted.map({ IndexPath(item: $0, section: self.sectionIndex) }))
+            }
+            if let changed = changes.changedIndexes, changed.isEmpty == false {
+                self.collectionView.reloadItems(at: changed.map({ IndexPath(item: $0, section: self.sectionIndex) }))
+            }
+            changes.enumerateMoves { fromIndex, toIndex in
+                self.collectionView.moveItem(at: IndexPath(item: fromIndex, section: self.sectionIndex), to: IndexPath(item: toIndex, section: self.sectionIndex))
+            }
+            }, completion: { finished in
+                self.completeOperation()
+        })
+        
+    }
+    
+}

--- a/ImagePicker/CollectionViewUpdatesCoordinator.swift
+++ b/ImagePicker/CollectionViewUpdatesCoordinator.swift
@@ -15,7 +15,6 @@ import Photos
 /// will prevent collection view from crashing on internal incosistency.
 ///
 final class CollectionViewUpdatesCoordinator {
-    
     deinit {
         log("deinit: \(String(describing: self))")
     }
@@ -40,7 +39,6 @@ final class CollectionViewUpdatesCoordinator {
     
     /// Updates collection view.
     func performChanges<PHAsset>(_ changes: PHFetchResultChangeDetails<PHAsset>, inSection: Int) {
-        
         if changes.hasIncrementalChanges {
             let operation = CollectionViewBatchAnimation(collectionView: collectionView, sectionIndex: inSection, changes: changes)
             serialMainQueue.addOperation(operation)
@@ -51,5 +49,4 @@ final class CollectionViewUpdatesCoordinator {
             }
         }
     }
-    
 }

--- a/ImagePicker/CollectionViewUpdatesCoordinator.swift
+++ b/ImagePicker/CollectionViewUpdatesCoordinator.swift
@@ -1,0 +1,55 @@
+//
+//  CollectionViewUpdatesCoordinator.swift
+//  ImagePicker
+//
+//  Created by Peter Stajger on 13/04/2018.
+//  Copyright © 2018 Inloop. All rights reserved.
+//
+
+import UIKit
+import Photos
+
+///
+/// Makes sure that all updates are performed in a serial queue, especially batch animations. This
+/// will make sure that reloadData() will never be called durring batch updates animations, which
+/// will prevent collection view from crashing on internal incosistency.
+///
+final class CollectionViewUpdatesCoordinator {
+    
+    deinit {
+        log("deinit: \(String(describing: self))")
+    }
+    
+    private let collectionView: UICollectionView
+    
+    private var serialMainQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.underlyingQueue = DispatchQueue.main
+        return queue
+    }()
+    
+    init(collectionView: UICollectionView) {
+        self.collectionView = collectionView
+    }
+    
+    /// Provides opportunuty to update collectionView's dataSource in underlaying queue.
+    func performDataSourceUpdate(updates: @escaping ()->Void) {
+        serialMainQueue.addOperation(updates)
+    }
+    
+    /// Updates collection view.
+    func performChanges<PHAsset>(_ changes: PHFetchResultChangeDetails<PHAsset>, inSection: Int) {
+        
+        if changes.hasIncrementalChanges {
+            let operation = CollectionViewBatchAnimation(collectionView: collectionView, sectionIndex: inSection, changes: changes)
+            serialMainQueue.addOperation(operation)
+        }
+        else {
+            serialMainQueue.addOperation { [unowned self] in
+                self.collectionView.reloadData()
+            }
+        }
+    }
+    
+}

--- a/ImagePicker/ImagePickerController.swift
+++ b/ImagePicker/ImagePickerController.swift
@@ -404,14 +404,12 @@ extension ImagePickerController: PHPhotoLibraryChangeObserver {
             return
         }
         
+        guard let changes = changeInstance.changeDetails(for: fetchResult) else {
+            return
+        }
+        
         DispatchQueue.main.sync {
         
-            guard let changes = changeInstance.changeDetails(for: fetchResult) else {
-                //reload collection view
-                self.collectionView.reloadData()
-                return
-            }
-            
             //update old fetch result with these updates
             collectionViewDataSource.assetsModel.fetchResult = changes.fetchResultAfterChanges
 

--- a/ImagePicker/ImagePickerController.swift
+++ b/ImagePicker/ImagePickerController.swift
@@ -405,11 +405,7 @@ extension ImagePickerController: PHPhotoLibraryChangeObserver {
     
     public func photoLibraryDidChange(_ changeInstance: PHChange) {
         
-        guard let fetchResult = collectionViewDataSource.assetsModel.fetchResult else {
-            return
-        }
-        
-        guard let changes = changeInstance.changeDetails(for: fetchResult) else {
+        guard let fetchResult = collectionViewDataSource.assetsModel.fetchResult, let changes = changeInstance.changeDetails(for: fetchResult) else {
             return
         }
         


### PR DESCRIPTION
*problem:* when incremental - animated changes were replaced by collectionView.reloadData() because it was crashing due to data source inconsistency this caused that collection view unselected selected cells. This is undesired as selection should be preserved.

*solution:* crash was caused because reloadData() was called when previous preformBatchUpdates was still animating, which caused datasource inconsistency. I implemented a fix, where all updates on collection view are done in a serial queue so there can't be any such inconsistencies. This way we can put back animated incremental updates. This will make sure that selection is preserved properly.